### PR TITLE
gemspec: rake 12.3.3+, allow Bundler 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: ruby
 rvm:
   - 2.3.0
-before_install: gem install bundler -v 1.11.2

--- a/banktools-dk.gemspec
+++ b/banktools-dk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 1.11"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This PR avoids a security advisory.